### PR TITLE
bump Scala 3 and sbt versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val scala3Version = "3.0.0"
+val scala3Version = "3.3.5"
 
 lazy val root = project
   .in(file("."))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.10.10


### PR DESCRIPTION
this came up on the Scala Discord today. Scala 3.0.0 is now so old that I don't trust current tooling to work with it

going all the way to Scala 3.6.4 would also be plausible 🤷 